### PR TITLE
Add introduction for RDF 1.2 interoperability specification

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -103,7 +103,7 @@
     the encoded graphs are not, in general, semantically [=equivalent=] to the
     originals under all entailment regimes. Instead, the focus is on faithful
     round-tripping of data structures so that information is not lost when moving
-    between implementations with different feature support.
+    between implementations that support different features.
   </p>
 
 </section>


### PR DESCRIPTION
This PR fills in the previously empty Introduction section of the RDF 1.2 Interoperability specification. The new text:

- Motivates the need for interoperability between RDF 1.1, RDF 1.2 Basic, and RDF 1.2 Full.
- Explains the role of triple terms and the distinction between conformance classes.
- Summarizes the purpose of the document (guidance and good practices for interoperability).
- Briefly outlines the transformations for basic encoding/decoding and their intended properties (information-preserving, idempotent, broadly applicable).